### PR TITLE
Enable social network links for person pages

### DIFF
--- a/content/project/person-phd-student-1.md
+++ b/content/project/person-phd-student-1.md
@@ -26,6 +26,11 @@ math = false
 image = "headers/bubbles-wide.jpg"
 caption = "My caption :smile:"
 
+# Optional social network links
+[social]
+github = "https://github.com/username"
+twitter = "https://twitter.com/username"
+linkedin = "https://www.linkedin.com/in/username/"
 +++
 
 <br>

--- a/themes/hugo-academic/layouts/partials/share.html
+++ b/themes/hugo-academic/layouts/partials/share.html
@@ -1,4 +1,19 @@
 {{ if .Site.Params.sharing }}
+{{ if and (isset .Params "tags") (in .Params.tags "person") (isset .Params "social") }}
+<div class="share-box" aria-hidden="true">
+  <ul class="share">
+  {{ range $key, $value := $.Params.social }}
+    <li>
+      <a class="{{ $key }}"
+         href="{{ $value | html }}"
+         target="_blank" rel="noopener">
+        <i class="fa fa-{{ $key }}"></i>
+      </a>
+    </li>
+  {{ end}}
+  </ul>
+</div>
+{{ else }}
 <div class="share-box" aria-hidden="true">
   <ul class="share">
     <li>
@@ -37,4 +52,5 @@
     </li>
   </ul>
 </div>
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Modify the "share" section to output social media links if the page
has the "person" tag.

This will need more work to get full range of buttons e.g. google
scholar, orcid. For now it works for the usual suspects, as per 
example in the modified markdown file.
